### PR TITLE
Add generation of static HTML docs served from API server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[*.{xml,yml}]
+[*.{xml,yml,json}]
 indent_size = 2
 
 [Makefile]

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,8 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace=true
+max_line_length=120
 
 [*.{xml,yml,json}]
 indent_size = 2

--- a/circle.yml
+++ b/circle.yml
@@ -26,3 +26,5 @@ test:
   post:
    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
    - find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+   - cp runtime/target/classes/index.html $CIRCLE_ARTIFACTS/apidocs.html
+   - cp runtime/target/classes/swagger.json $CIRCLE_ARTIFACTS/

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,17 @@
     </repository>
   </distributionManagement>
 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter-releases</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com</url>
+    </repository>
+  </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <snapshots>
@@ -80,7 +91,18 @@
       </snapshots>
       <id>jcenter-releases</id>
       <name>jcenter</name>
-      <url>http://jcenter.bintray.com</url>
+      <url>https://jcenter.bintray.com</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>apache.snapshots</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </pluginRepository>
   </pluginRepositories>
 
@@ -100,6 +122,7 @@
     <maven.resources.plugin.version>3.0.1</maven.resources.plugin.version>
     <maven.source.plugin.version>2.4</maven.source.plugin.version>
     <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
+    <maven.dependency.plugin.version>3.0.0-SNAPSHOT</maven.dependency.plugin.version>
     <maven.swagger.plugin.version>3.1.4</maven.swagger.plugin.version>
     <templating.maven.plugin.version>1.0.0</templating.maven.plugin.version>
 
@@ -134,6 +157,11 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven.dependency.plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   ~
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -73,6 +73,17 @@
     </repository>
   </distributionManagement>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter-releases</id>
+      <name>jcenter</name>
+      <url>http://jcenter.bintray.com</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -89,10 +100,10 @@
     <maven.resources.plugin.version>3.0.1</maven.resources.plugin.version>
     <maven.source.plugin.version>2.4</maven.source.plugin.version>
     <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
-
+    <maven.swagger.plugin.version>3.1.4</maven.swagger.plugin.version>
+    <templating.maven.plugin.version>1.0.0</templating.maven.plugin.version>
 
     <fabric8.maven.plugin.version>3.2.8</fabric8.maven.plugin.version>
-    <templating.maven.plugin.version>1.0.0</templating.maven.plugin.version>
   </properties>
 
   <modules>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,15 @@
-# IPaaS API
+# Red Hat iPaaS API
+
+[![CircleCI](https://img.shields.io/circleci/project/github/redhat-ipaas/ipaas-api-java.svg)](https://circleci.com/gh/redhat-ipaas/ipaas-api-java)
+[![Maven Central](https://img.shields.io/maven-central/v/com.redhat.ipaas/ipaas-api-java.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22redhat-ipaas%22%20AND%20a%3A%22ipaas-api-java%22)
 
 - [Building](#building)
 - [Running](#run-in-development-mode)
 - [Deploying](#deploying-to-kubernetes) 
 - [Endpoints](#endpoints)
+
+### Swagger
+[![Swagger](https://online.swagger.io/validator?url=https://circleci.com/api/v1/project/redhat-ipaas/ipaas-api-java/latest/artifacts/0/$CIRCLE_ARTIFACTS/swagger.json)](https://online.swagger.io/validator/debug?url=https://circleci.com/api/v1/project/redhat-ipaas/ipaas-api-java/latest/artifacts/0/$CIRCLE_ARTIFACTS/swagger.json)
 
 # Building
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -8,7 +8,7 @@
 	License for the specific language governing permissions and ~ limitations
 	under the License. ~ -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -23,6 +23,11 @@
 
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+
+    <apidocs.dir>${project.build.directory}/api-docs</apidocs.dir>
+    <apidocs.output.dir>${project.build.outputDirectory}</apidocs.output.dir>
+
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
   </properties>
 
   <dependencyManagement>
@@ -73,6 +78,101 @@
               <goal>resource</goal>
               <goal>helm</goal>
               <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>${maven.swagger.plugin.version}</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <locations>
+                <location>com.redhat.ipaas.rest</location>
+              </locations>
+              <swaggerDirectory>${apidocs.output.dir}</swaggerDirectory>
+              <schemes>
+                <scheme>http</scheme>
+                <scheme>https</scheme>
+              </schemes>
+              <host>localhost:8080</host>
+              <basePath>/v1</basePath>
+              <info>
+                <title>Red Hat iPaaS API</title>
+                <version>v1</version>
+                <description>
+                  The Red Hat iPaaS REST API connects to back-end services on the IPaaS and provides a single entry point for the IpaaS Console. For console developement it can run in off-line mode where it only serves responses from the response cache.
+                </description>
+                <license>
+                  <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                  <name>Apache 2.0</name>
+                </license>
+                <contact>
+                  <email>ipaas-dev@redhat.com</email>
+                  <name>The Red Hat iPaaS Developers</name>
+                  <url>https://redhat-ipaas.github.io</url>
+                </contact>
+              </info>
+              <attachSwaggerArtifact>true</attachSwaggerArtifact>
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.github.swagger2markup</groupId>
+        <artifactId>swagger2markup-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <swaggerInput>${apidocs.output.dir}/swagger.json</swaggerInput>
+          <outputDir>${apidocs.dir}/asciidoc</outputDir>
+          <config>
+            <swagger2markup.markupLanguage>ASCIIDOC</swagger2markup.markupLanguage>
+          </config>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>convertSwagger2markup</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>1.5.3</version>
+        <configuration>
+          <sourceDirectory>${project.basedir}/src/docs/asciidoc</sourceDirectory>
+          <sourceDocumentName>index.adoc</sourceDocumentName>
+          <outputDirectory>${apidocs.output.dir}</outputDirectory>
+          <backend>html5</backend>
+          <sourceHighlighter>coderay</sourceHighlighter>
+          <attributes>
+            <generated>${apidocs.dir}/asciidoc</generated>
+            <toc>left</toc>
+            <sectnums>true</sectnums>
+            <revnumber>${project.version}</revnumber>
+            <revdate>${maven.build.timestamp}</revdate>
+            <organization>${project.organization.name}</organization>
+          </attributes>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>process-asciidoc</goal>
             </goals>
           </execution>
         </executions>

--- a/runtime/src/docs/asciidoc/index.adoc
+++ b/runtime/src/docs/asciidoc/index.adoc
@@ -1,0 +1,4 @@
+include::{generated}/overview.adoc[]
+include::{generated}/paths.adoc[]
+include::{generated}/definitions.adoc[]
+include::{generated}/security.adoc[]

--- a/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.ComponentGroup;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -26,29 +27,29 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/componentgroups")
 @Api(value = "componentgroups")
 public class ComponentGroups {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<ComponentGroup> list() {
-		return dataMgr.fetchAll(ComponentGroup.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public ComponentGroup get(
-			@ApiParam(value = "id of the ComponentGroup", required = true) @PathParam("id") String id) {
-		return dataMgr.fetch(ComponentGroup.class,id);
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List component groups")
+    public Collection<ComponentGroup> list() {
+        return dataMgr.fetchAll(ComponentGroup.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get component group by ID")
+    public ComponentGroup get(
+        @ApiParam(value = "id of the ComponentGroup", required = true) @PathParam("id") String id) {
+        return dataMgr.fetch(ComponentGroup.class, id);
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.ComponentGroup;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -39,6 +41,7 @@ public class ComponentGroups {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List component groups")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = ComponentGroup.class)})
     public Collection<ComponentGroup> list() {
         return dataMgr.fetchAll(ComponentGroup.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -21,6 +21,8 @@ import com.redhat.ipaas.api.ComponentGroup;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -40,6 +42,7 @@ public class Components {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List components")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Component.class)})
     public Collection<Component> list() {
         return dataMgr.fetchAll(Component.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -18,8 +18,9 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Component;
 import com.redhat.ipaas.api.ComponentGroup;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -27,34 +28,34 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/components")
 @Api(value = "components")
 public class Components {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<Component> list() {
-		return dataMgr.fetchAll(Component.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public Component get(
-			@ApiParam(value = "id of the Component", required = true) @PathParam("id") String id) {
-		Component component = dataMgr.fetch(Component.class,id);
-		if (component.getComponentGroupId()!=null) {
-			ComponentGroup cg = dataMgr.fetch(ComponentGroup.class, component.getComponentGroupId());
-			component.setComponentGroup(cg);
-		}
-		return component;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List components")
+    public Collection<Component> list() {
+        return dataMgr.fetchAll(Component.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get component by ID")
+    public Component get(
+        @ApiParam(value = "id of the Component", required = true) @PathParam("id") String id) {
+        Component component = dataMgr.fetch(Component.class, id);
+        if (component.getComponentGroupId() != null) {
+            ComponentGroup cg = dataMgr.fetch(ComponentGroup.class, component.getComponentGroupId());
+            component.setComponentGroup(cg);
+        }
+        return component;
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Connection;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -30,58 +31,60 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/connections")
 @Api(value = "connections")
 public class Connections {
 
-	@Inject
-	private DataManager dataMgr;
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<Connection> list() {
-		return dataMgr.fetchAll(Connection.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public Connection get(
-			@ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
-		return dataMgr.fetch(Connection.class,id);
-	}
-	
-	@POST
-	@Produces(MediaType.APPLICATION_JSON)
-	@Consumes("application/json")
-	public String create(Connection connection) {
-		String id = dataMgr.create(connection);
-		return id;
-	}
-	
-	@PUT
-	@Path(value="/{id}")
-	@Consumes("application/json")
-	public void update(
-			@ApiParam(value = "id of the connection", required = true) @PathParam("id") String id, 
-			Connection connection) {
-		dataMgr.update(connection);
-		
-	}
-	
-	@DELETE
-	@Consumes("application/json")
-	@Path(value="/{id}")
-	public void delete(
-			@ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
-		dataMgr.delete(Connection.class, id);
-		
-	}
-	
-	
-	
+    @Inject
+    private DataManager dataMgr;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List connections")
+    public Collection<Connection> list() {
+        return dataMgr.fetchAll(Connection.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get connection by ID")
+    public Connection get(
+        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
+        return dataMgr.fetch(Connection.class, id);
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes("application/json")
+    @ApiOperation(value = "Create a new connection")
+    public String create(Connection connection) {
+        String id = dataMgr.create(connection);
+        return id;
+    }
+
+    @PUT
+    @Path(value = "/{id}")
+    @Consumes("application/json")
+    @ApiOperation(value = "Update a connection")
+    public void update(
+        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
+        Connection connection) {
+        dataMgr.update(connection);
+
+    }
+
+    @DELETE
+    @Consumes("application/json")
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Delete a connection")
+    public void delete(
+        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
+        dataMgr.delete(Connection.class, id);
+
+    }
+
+
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.Connection;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -43,6 +45,7 @@ public class Connections {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List connections")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Connection.class)})
     public Collection<Connection> list() {
         return dataMgr.fetchAll(Connection.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -21,6 +21,8 @@ import com.redhat.ipaas.api.IntegrationPatternGroup;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -40,6 +42,7 @@ public class IntegrationPatterns {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration patterns")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationPattern.class)})
     public Collection<IntegrationPattern> list() {
         return dataMgr.fetchAll(IntegrationPattern.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -18,8 +18,9 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.IntegrationPattern;
 import com.redhat.ipaas.api.IntegrationPatternGroup;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -27,34 +28,34 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/integrationpatterns")
 @Api(value = "integrationpatterns")
 public class IntegrationPatterns {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<IntegrationPattern> list() {
-		return dataMgr.fetchAll(IntegrationPattern.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public IntegrationPattern get(
-			@ApiParam(value = "id of the IntegrationPattern", required = true) @PathParam("id") String id) {
-		IntegrationPattern ip = dataMgr.fetch(IntegrationPattern.class,id);
-		if (ip.getIntegrationPatternGroupId()!=null) {
-			IntegrationPatternGroup ipg = dataMgr.fetch(IntegrationPatternGroup.class,ip.getIntegrationPatternGroupId());
-		    ip.setIntegrationPatternGroup(ipg);
-		}
-		return ip;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List integration patterns")
+    public Collection<IntegrationPattern> list() {
+        return dataMgr.fetchAll(IntegrationPattern.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get an integration patten by ID")
+    public IntegrationPattern get(
+        @ApiParam(value = "id of the IntegrationPattern", required = true) @PathParam("id") String id) {
+        IntegrationPattern ip = dataMgr.fetch(IntegrationPattern.class, id);
+        if (ip.getIntegrationPatternGroupId() != null) {
+            IntegrationPatternGroup ipg = dataMgr.fetch(IntegrationPatternGroup.class, ip.getIntegrationPatternGroupId());
+            ip.setIntegrationPatternGroup(ipg);
+        }
+        return ip;
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.IntegrationTemplate;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -43,6 +45,7 @@ public class IntegrationTemplates {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration templates")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationTemplate.class)})
     public Collection<IntegrationTemplate> list() {
         return dataMgr.fetchAll(IntegrationTemplate.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.IntegrationTemplate;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -30,57 +31,60 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/integrationtemplates")
 @Api(value = "integrationtemplates")
 public class IntegrationTemplates {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<IntegrationTemplate> list() {
-		return dataMgr.fetchAll(IntegrationTemplate.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public IntegrationTemplate get(
-			@ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
-		IntegrationTemplate it = dataMgr.fetch(IntegrationTemplate.class,id);
-		
-		return it;
-	}
-	
-	@POST
-	@Produces(MediaType.APPLICATION_JSON)
-	@Consumes("application/json")
-	public String create(IntegrationTemplate integrationTemplate) {
-		String id = dataMgr.create(integrationTemplate);
-		return id;
-	}
-	
-	@PUT
-	@Path(value="/{id}")
-	@Consumes("application/json")
-	public void update(
-			@ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
-			IntegrationTemplate integrationTemplate) {
-		dataMgr.update(integrationTemplate);
-		
-	}
-	
-	@DELETE
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public void delete(
-			@ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
-		dataMgr.delete(IntegrationTemplate.class,id);
-	}
-	
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List integration templates")
+    public Collection<IntegrationTemplate> list() {
+        return dataMgr.fetchAll(IntegrationTemplate.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get an integration template by ID")
+    public IntegrationTemplate get(
+        @ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
+        IntegrationTemplate it = dataMgr.fetch(IntegrationTemplate.class, id);
+
+        return it;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes("application/json")
+    @ApiOperation(value = "Create an integration template")
+    public String create(IntegrationTemplate integrationTemplate) {
+        String id = dataMgr.create(integrationTemplate);
+        return id;
+    }
+
+    @PUT
+    @Path(value = "/{id}")
+    @Consumes("application/json")
+    @ApiOperation(value = "Update a connection")
+    public void update(
+        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
+        IntegrationTemplate integrationTemplate) {
+        dataMgr.update(integrationTemplate);
+
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Delete an integration template")
+    public void delete(
+        @ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
+        dataMgr.delete(IntegrationTemplate.class, id);
+    }
+
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Integration;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -30,58 +31,61 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/integrations")
 @Api(value = "integrations")
 public class Integrations {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<Integration> list() {
-		return dataMgr.fetchAll(Integration.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public Integration get(
-			@ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
-		Integration i = dataMgr.fetch(Integration.class,id);
-		
-		return i;
-	}
-	
-	@POST
-	@Produces(MediaType.APPLICATION_JSON)
-	@Consumes("application/json")
-	public String create(Integration integration) {
-		String id = dataMgr.create(integration);
-		return id;
-	}
-	
-	@PUT
-	@Path(value="/{id}")
-	@Consumes("application/json")
-	public void update(
-			@ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
-			Integration integration) {
-		dataMgr.update(integration);
-		
-	}
-	
-	@DELETE
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public void delete(
-			@ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
-		dataMgr.delete(Integration.class,id);
-	}
-	
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List integrations")
+    public Collection<Integration> list() {
+        return dataMgr.fetchAll(Integration.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get an integration by ID")
+    public Integration get(
+        @ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
+        Integration i = dataMgr.fetch(Integration.class, id);
+
+        return i;
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes("application/json")
+    @ApiOperation(value = "Create an integration")
+    public String create(Integration integration) {
+        String id = dataMgr.create(integration);
+        return id;
+    }
+
+    @PUT
+    @Path(value = "/{id}")
+    @Consumes("application/json")
+    @ApiOperation(value = "Update a connection")
+    public void update(
+        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
+        Integration integration) {
+        dataMgr.update(integration);
+
+    }
+
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Delete a connection")
+    public void delete(
+        @ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
+        dataMgr.delete(Integration.class, id);
+    }
+
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.Integration;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -43,6 +45,7 @@ public class Integrations {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integrations")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Integration.class)})
     public Collection<Integration> list() {
         return dataMgr.fetchAll(Integration.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Organizations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Organizations.java
@@ -16,26 +16,25 @@
  */
 package com.redhat.ipaas.rest;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.core.MediaType;
-
 import com.redhat.ipaas.api.Organization;
-
-import java.util.HashSet;
-import java.util.Set;
+import io.swagger.annotations.ApiOperation;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.HashSet;
+import java.util.Set;
 
 @Path("/organizations")
 public class Organizations {
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	
-	public Set<Organization> doGet() {
-		
-		Set<Organization> orgs = new HashSet<Organization>();
-		return orgs;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get an organization by ID")
+    public Set<Organization> doGet() {
+
+        Set<Organization> orgs = new HashSet<Organization>();
+        return orgs;
+    }
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.Permission;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -39,6 +41,7 @@ public class Permissions {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List permissions")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Permission.class)})
     public Collection<Permission> list() {
         return dataMgr.fetchAll(Permission.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Permission;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -26,31 +27,31 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/permissions")
 @Api(value = "permissions")
 public class Permissions {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<Permission> list() {
-		return dataMgr.fetchAll(Permission.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public Permission get(
-			@ApiParam(value = "id of the Permission", required = true) @PathParam("id") String id) {
-		Permission permission = dataMgr.fetch(Permission.class,id);
-		
-		return permission;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List permissions")
+    public Collection<Permission> list() {
+        return dataMgr.fetchAll(Permission.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get a permission by ID")
+    public Permission get(
+        @ApiParam(value = "id of the Permission", required = true) @PathParam("id") String id) {
+        Permission permission = dataMgr.fetch(Permission.class, id);
+
+        return permission;
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.Role;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -39,6 +41,7 @@ public class Roles {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List roles")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Role.class)})
     public Collection<Role> list() {
         return dataMgr.fetchAll(Role.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -17,8 +17,9 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Role;
-
-import java.util.Collection;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -26,31 +27,31 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/roles")
 @Api(value = "roles")
 public class Roles {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<Role> list() {
-		return dataMgr.fetchAll(Role.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public Role get(
-			@ApiParam(value = "id of the Role", required = true) @PathParam("id") String id) {
-		Role role = dataMgr.fetch(Role.class,id);
-		
-		return role;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List roles")
+    public Collection<Role> list() {
+        return dataMgr.fetchAll(Role.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get a role by ID")
+    public Role get(
+        @ApiParam(value = "id of the Role", required = true) @PathParam("id") String id) {
+        Role role = dataMgr.fetch(Role.class, id);
+
+        return role;
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
@@ -20,6 +20,8 @@ import com.redhat.ipaas.api.User;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -39,6 +41,7 @@ public class Users {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List users")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = User.class)})
     public Collection<User> list() {
         return dataMgr.fetchAll(User.class);
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
@@ -16,7 +16,10 @@
  */
 package com.redhat.ipaas.rest;
 
-import java.util.Collection;
+import com.redhat.ipaas.api.User;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -24,33 +27,31 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import com.redhat.ipaas.api.User;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import java.util.Collection;
 
 @Path("/users")
 @Api(value = "users")
 public class Users {
 
-	@Inject
-	private DataManager dataMgr;
+    @Inject
+    private DataManager dataMgr;
 
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	public Collection<User> list() {
-		return dataMgr.fetchAll(User.class);
-	}
-	
-	@GET
-	@Produces(MediaType.APPLICATION_JSON)
-	@Path(value="/{id}")
-	public User get(
-			@ApiParam(value = "id of the User", required = true) @PathParam("id") String id) {
-		User user = dataMgr.fetch(User.class,id);
-		
-		return user;
-	}
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List users")
+    public Collection<User> list() {
+        return dataMgr.fetchAll(User.class);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    @ApiOperation(value = "Get a user by ID")
+    public User get(
+        @ApiParam(value = "id of the User", required = true) @PathParam("id") String id) {
+        User user = dataMgr.fetch(User.class, id);
+
+        return user;
+    }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/VersionEndpoint.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/VersionEndpoint.java
@@ -18,18 +18,20 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.Version;
+import io.swagger.annotations.ApiOperation;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
 
 @Path("/version")
 public class VersionEndpoint {
-	
-	@GET
-	@Produces("text/plain")
-	public Response doGet() {
-		return Response.ok(Version.getVersion()).build();
-	}
+
+    @GET
+    @Produces("text/plain")
+    @ApiOperation(value = "Get the version")
+    public Response doGet() {
+        return Response.ok(Version.getVersion()).build();
+    }
 }


### PR DESCRIPTION
When run with `java -jar target/swarm-runtime.jar`, static HTML docs are served
from http://localhost:8080. Haven't figured out how to get those embedded in dev
mode, but that's less important anyway.