### PR TITLE
Add support for sorting for all list operations

### DIFF
--- a/api/src/main/java/com/redhat/ipaas/api/v1/model/WithName.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/model/WithName.java
@@ -17,6 +17,6 @@ package com.redhat.ipaas.api.v1.model;
 
 public interface WithName {
 
-    String name();
+    String getName();
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.ComponentGroup;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -24,10 +25,13 @@ import io.swagger.annotations.ApiResponses;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/componentgroups")
@@ -37,12 +41,15 @@ public class ComponentGroups {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List component groups")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = ComponentGroup.class)})
     public Collection<ComponentGroup> list() {
-        return dataMgr.fetchAll(ComponentGroup.KIND);
+        return dataMgr.fetchAll(ComponentGroup.KIND, new ReflectiveSorter<>(ComponentGroup.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -17,6 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Component;
 import com.redhat.ipaas.api.v1.model.ComponentGroup;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -28,7 +29,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/components")
@@ -38,12 +41,16 @@ public class Components {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List components")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Component.class)})
+    @ApiParam(name = "sortField", value = "Sort list with the given field")
     public Collection<Component> list() {
-        return dataMgr.fetchAll(Component.KIND);
+        return dataMgr.fetchAll(Component.KIND, new ReflectiveSorter<>(Component.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -37,9 +37,6 @@ public class Components {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List components")
@@ -53,7 +50,7 @@ public class Components {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<Component> list() {
+    public Collection<Component> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(Component.KIND, new ReflectiveSorter<>(Component.class, new SortOptionsFromQueryParams(uri)));
     }
 

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -18,11 +18,7 @@ package com.redhat.ipaas.rest;
 import com.redhat.ipaas.api.v1.model.Component;
 import com.redhat.ipaas.api.v1.model.ComponentGroup;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -48,7 +44,15 @@ public class Components {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List components")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Component.class)})
-    @ApiParam(name = "sortField", value = "Sort list with the given field")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<Component> list() {
         return dataMgr.fetchAll(Component.KIND, new ReflectiveSorter<>(Component.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Connection;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -51,6 +47,15 @@ public class Connections {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List connections")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Connection.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<Connection> list() {
         return dataMgr.fetchAll(Connection.KIND, new ReflectiveSorter<>(Connection.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Connection;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -31,7 +32,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/connections")
@@ -41,12 +44,15 @@ public class Connections {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List connections")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Connection.class)})
     public Collection<Connection> list() {
-        return dataMgr.fetchAll(Connection.KIND);
+        return dataMgr.fetchAll(Connection.KIND, new ReflectiveSorter<>(Connection.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -40,9 +40,6 @@ public class Connections {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List connections")
@@ -56,7 +53,7 @@ public class Connections {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<Connection> list() {
+    public Collection<Connection> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(Connection.KIND, new ReflectiveSorter<>(Connection.class, new SortOptionsFromQueryParams(uri)));
     }
 

--- a/runtime/src/main/java/com/redhat/ipaas/rest/DataManager.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/DataManager.java
@@ -48,11 +48,13 @@ import javax.inject.Inject;
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 @ApplicationScoped
 public class DataManager {
@@ -175,9 +177,14 @@ public class DataManager {
         throw new ClassNotFoundException("No class found for model " + model);
     }
 
-    public <T> Collection<T> fetchAll(String model) {
+    @SuppressWarnings("unchecked")
+    public <T> List<T> fetchAll(String model, Function<List<T>, List<T>>... operators) {
         Map<String, WithId> entityMap = cache.computeIfAbsent(model, k -> new HashMap<>());
-        return (Collection<T>) entityMap.values();
+        List<T> result = new ArrayList<>((Collection<? extends T>) entityMap.values());
+        for (Function<List<T>, List<T>> operator : operators) {
+            result = operator.apply(result);
+        }
+        return result;
     }
 
     public <T> T fetch(String model, String id) {

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -18,11 +18,7 @@ package com.redhat.ipaas.rest;
 import com.redhat.ipaas.api.v1.model.IntegrationPattern;
 import com.redhat.ipaas.api.v1.model.IntegrationPatternGroup;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -48,6 +44,15 @@ public class IntegrationPatterns {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration patterns")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationPattern.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<IntegrationPattern> list() {
         return dataMgr.fetchAll(IntegrationPattern.KIND,
             new ReflectiveSorter<>(IntegrationPattern.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -37,9 +37,6 @@ public class IntegrationPatterns {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration patterns")
@@ -53,7 +50,7 @@ public class IntegrationPatterns {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<IntegrationPattern> list() {
+    public Collection<IntegrationPattern> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(IntegrationPattern.KIND,
             new ReflectiveSorter<>(IntegrationPattern.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -17,6 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.IntegrationPattern;
 import com.redhat.ipaas.api.v1.model.IntegrationPatternGroup;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -28,7 +29,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/integrationpatterns")
@@ -38,12 +41,16 @@ public class IntegrationPatterns {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration patterns")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationPattern.class)})
     public Collection<IntegrationPattern> list() {
-        return dataMgr.fetchAll(IntegrationPattern.KIND);
+        return dataMgr.fetchAll(IntegrationPattern.KIND,
+            new ReflectiveSorter<>(IntegrationPattern.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.IntegrationTemplate;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -31,7 +32,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/integrationtemplates")
@@ -41,12 +44,16 @@ public class IntegrationTemplates {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration templates")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationTemplate.class)})
     public Collection<IntegrationTemplate> list() {
-        return dataMgr.fetchAll(IntegrationTemplate.KIND);
+        return dataMgr.fetchAll(IntegrationTemplate.KIND,
+            new ReflectiveSorter<>(IntegrationTemplate.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -40,9 +40,6 @@ public class IntegrationTemplates {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration templates")
@@ -56,7 +53,7 @@ public class IntegrationTemplates {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<IntegrationTemplate> list() {
+    public Collection<IntegrationTemplate> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(IntegrationTemplate.KIND,
             new ReflectiveSorter<>(IntegrationTemplate.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.IntegrationTemplate;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -51,6 +47,15 @@ public class IntegrationTemplates {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integration templates")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationTemplate.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<IntegrationTemplate> list() {
         return dataMgr.fetchAll(IntegrationTemplate.KIND,
             new ReflectiveSorter<>(IntegrationTemplate.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Integration;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -51,6 +47,15 @@ public class Integrations {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integrations")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Integration.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<Integration> list() {
         return dataMgr.fetchAll(Integration.KIND,
             new ReflectiveSorter<>(Integration.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -41,8 +41,6 @@ public class Integrations {
     private DataManager dataMgr;
 
     @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integrations")
@@ -56,7 +54,7 @@ public class Integrations {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<Integration> list() {
+    public Collection<Integration> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(Integration.KIND,
             new ReflectiveSorter<>(Integration.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Integration;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -31,7 +32,9 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/integrations")
@@ -41,12 +44,16 @@ public class Integrations {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List integrations")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Integration.class)})
     public Collection<Integration> list() {
-        return dataMgr.fetchAll(Integration.KIND);
+        return dataMgr.fetchAll(Integration.KIND,
+            new ReflectiveSorter<>(Integration.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -36,9 +36,6 @@ public class Permissions {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List permissions")
@@ -52,7 +49,7 @@ public class Permissions {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<Permission> list() {
+    public Collection<Permission> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(Permission.KIND,
             new ReflectiveSorter<>(Permission.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Permission;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -27,7 +28,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/permissions")
@@ -37,12 +40,16 @@ public class Permissions {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List permissions")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Permission.class)})
     public Collection<Permission> list() {
-        return dataMgr.fetchAll(Permission.KIND);
+        return dataMgr.fetchAll(Permission.KIND,
+            new ReflectiveSorter<>(Permission.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Permission;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -47,6 +43,15 @@ public class Permissions {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List permissions")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Permission.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<Permission> list() {
         return dataMgr.fetchAll(Permission.KIND,
             new ReflectiveSorter<>(Permission.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Role;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -27,7 +28,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/roles")
@@ -37,12 +40,16 @@ public class Roles {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List roles")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Role.class)})
     public Collection<Role> list() {
-        return dataMgr.fetchAll(Role.KIND);
+        return dataMgr.fetchAll(Role.KIND,
+            new ReflectiveSorter<>(Role.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Role;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -47,6 +43,15 @@ public class Roles {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List roles")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Role.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<Role> list() {
         return dataMgr.fetchAll(Role.KIND,
             new ReflectiveSorter<>(Role.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -36,9 +36,6 @@ public class Roles {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List roles")
@@ -52,7 +49,7 @@ public class Roles {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<Role> list() {
+    public Collection<Role> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(Role.KIND,
             new ReflectiveSorter<>(Role.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/SortOptionsFromQueryParams.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/SortOptionsFromQueryParams.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.rest;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import com.redhat.ipaas.rest.util.SortOptions;
+
+/**
+ * @author roland
+ * @since 14/12/16
+ */
+class SortOptionsFromQueryParams implements SortOptions {
+
+    private final String sortField;
+    private final SortDirection sortDirection;
+
+    SortOptionsFromQueryParams(UriInfo uri) {
+        MultivaluedMap<String, String> queryParams = uri.getQueryParameters();
+        sortField = queryParams.getFirst("sort");
+        String dir = queryParams.getFirst("direction");
+        sortDirection = dir == null ?  SortOptions.SortDirection.ASC : SortOptions.SortDirection.valueOf(dir.toUpperCase());
+    }
+
+    @Override
+    public String getSortField() {
+        return sortField;
+    }
+
+    @Override
+    public SortDirection getSortDirection() {
+        return sortDirection;
+    }
+}

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
@@ -17,11 +17,7 @@ package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.User;
 import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -47,6 +43,15 @@ public class Users {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List users")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = User.class)})
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
     public Collection<User> list() {
         return dataMgr.fetchAll(User.KIND,
             new ReflectiveSorter<>(User.class, new SortOptionsFromQueryParams(uri)));

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
@@ -16,6 +16,7 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.User;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -27,7 +28,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 
 @Path("/users")
@@ -37,12 +40,16 @@ public class Users {
     @Inject
     private DataManager dataMgr;
 
+    @Context
+    private UriInfo uri;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List users")
     @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = User.class)})
     public Collection<User> list() {
-        return dataMgr.fetchAll(User.KIND);
+        return dataMgr.fetchAll(User.KIND,
+            new ReflectiveSorter<>(User.class, new SortOptionsFromQueryParams(uri)));
     }
 
     @GET

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Users.java
@@ -36,9 +36,6 @@ public class Users {
     @Inject
     private DataManager dataMgr;
 
-    @Context
-    private UriInfo uri;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List users")
@@ -52,7 +49,7 @@ public class Users {
                                         "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
 
     })
-    public Collection<User> list() {
+    public Collection<User> list(@Context UriInfo uri) {
         return dataMgr.fetchAll(User.KIND,
             new ReflectiveSorter<>(User.class, new SortOptionsFromQueryParams(uri)));
     }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/util/ReflectiveSorter.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/util/ReflectiveSorter.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.rest.util;
+
+import java.lang.reflect.Field;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Generic comparator which sorts based on fields. Fields are retrieved by reflections
+ *
+ * @author roland
+ * @since 13/12/16
+ */
+public class ReflectiveSorter<T> implements Function<List<T>, List<T>>, Comparator<T> {
+
+    private Comparator<T> delegate;
+
+    @Override
+    public List<T> apply(List<T> list) {
+        if (delegate != null) {
+            // We are sorting inline when a delegate is given. Otherwise its a no-op
+            list.sort(this);
+        }
+        return list;
+    }
+
+    public ReflectiveSorter(Class<T> modelClass, SortOptions options) {
+        String sortField = options.getSortField();
+        if (sortField == null) {
+            // No sorting
+            delegate = null;
+        } else {
+            delegate = createDelegateComparator(modelClass, sortField);
+
+            if (options.getSortDirection() == SortOptions.SortDirection.DESC) {
+                delegate = delegate.reversed();
+            }
+        }
+    }
+
+    private Comparator<T> createDelegateComparator(Class<T> modelClass, String fieldName) {
+        Comparator<T> delegate = getIntComparator(modelClass, fieldName);
+        if (delegate != null) {
+            return delegate;
+        }
+
+        delegate = getStringComparator(modelClass, fieldName);
+        if (delegate != null) {
+            return delegate;
+        }
+
+        throw new IllegalArgumentException(String.format("Cannot find field %s in %s as int or String field",fieldName, modelClass.getName()));
+    }
+
+    private Comparator<T> getStringComparator(Class<T> modelClass, String fieldName) {
+        Field stringField = getFieldOfType(modelClass, fieldName, String.class);
+        if (stringField != null) {
+            return Comparator.comparing(k -> {
+                try {
+                    stringField.setAccessible(true);
+                    return (String) stringField.get(k);
+                } catch (IllegalAccessException e) {
+                    throw new IllegalArgumentException("Cannot extract String value of field " + stringField + " for object " + k, e);
+                }
+            });
+        }
+        return null;
+    }
+
+    private Comparator<T> getIntComparator(Class<T> modelClass, String fieldName) {
+        Field intField = getFieldOfType(modelClass, fieldName, int.class, Integer.class);
+        if (intField != null) {
+            return Comparator.comparingInt(k -> {
+                        try {
+                            intField.setAccessible(true);
+                            return (Integer) intField.get(k);
+                        } catch (IllegalAccessException e) {
+                            throw new IllegalArgumentException("Cannot extract int value of field " + intField + " for object " + k, e);
+                        }
+            });
+        }
+        return null;
+    }
+
+
+    private Field getFieldOfType(Class clazz, String fieldName, Class ... types) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            Class fieldClass = field.getType();
+            for (Class type : types) {
+                if (fieldClass.isAssignableFrom(type)) {
+                    return field;
+                }
+            }
+            return null;
+        } catch (NoSuchFieldException exp) {
+            return null;
+        }
+    }
+
+    @Override
+    public int compare(T o1, T o2) {
+        return delegate.compare(o1,o2);
+    }
+
+}

--- a/runtime/src/main/java/com/redhat/ipaas/rest/util/ReflectiveSorter.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/util/ReflectiveSorter.java
@@ -74,7 +74,6 @@ public class ReflectiveSorter<T> implements Function<List<T>, List<T>>, Comparat
         if (stringGetMethod != null) {
             return Comparator.comparing(k -> {
                 try {
-                    stringGetMethod.setAccessible(true);
                     return (String) stringGetMethod.invoke(k);
                 } catch (InvocationTargetException | IllegalAccessException e) {
                     throw new IllegalArgumentException("Cannot extract String value from " + stringGetMethod + " for object " + k, e);
@@ -89,7 +88,6 @@ public class ReflectiveSorter<T> implements Function<List<T>, List<T>>, Comparat
         if (intGetMethod != null) {
             return Comparator.comparingInt(k -> {
                         try {
-                            intGetMethod.setAccessible(true);
                             return (Integer) intGetMethod.invoke(k);
                         } catch (InvocationTargetException | IllegalAccessException e) {
                             throw new IllegalArgumentException("Cannot extract int value from " + intGetMethod + " for object " + k, e);

--- a/runtime/src/main/java/com/redhat/ipaas/rest/util/SortOptions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/util/SortOptions.java
@@ -13,27 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.redhat.ipaas.rest;
+package com.redhat.ipaas.rest.util;
 
-import com.redhat.ipaas.api.v1.model.Organization;
-import io.swagger.annotations.ApiOperation;
+/**
+ * @author roland
+ * @since 14/12/16
+ */
+public interface SortOptions {
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import java.util.HashSet;
-import java.util.Set;
+    String getSortField();
+    SortDirection getSortDirection();
 
-@Path("/organizations")
-public class Organizations {
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get an organization by ID")
-    public Set<Organization> doGet() {
-
-        Set<Organization> orgs = new HashSet<>();
-        return orgs;
+    enum SortDirection {
+        ASC,
+        DESC;
     }
 }

--- a/runtime/src/main/java/com/redhat/ipaas/runtime/Main.java
+++ b/runtime/src/main/java/com/redhat/ipaas/runtime/Main.java
@@ -47,7 +47,7 @@ public class Main {
             setResourcePackages("com.redhat.ipaas.rest");
         JAXRSArchive jaxrs = archive.as(JAXRSArchive.class).
             setContextRoot("v1").
-            addPackage("com.redhat.ipaas.rest").
+            addPackages(true, "com.redhat.ipaas.rest").
             addClass(VersionEndpoint.class).
             addAllDependencies();
 

--- a/runtime/src/test/java/com/redhat/ipaas/rest/DataManagerTest.java
+++ b/runtime/src/test/java/com/redhat/ipaas/rest/DataManagerTest.java
@@ -53,8 +53,8 @@ public class DataManagerTest {
 	@Test
 	public void getComponent() {
 	    Component component = dataManager.fetch(Component.KIND,"1");
-		System.out.println(component.name());
-		assertEquals("First Component in the deployment.json is non", "non", component.name());
+		System.out.println(component.getName());
+		assertEquals("First Component in the deployment.json is non", "non", component.getName());
 	}
 
 	@Test(expected = EntityExistsException.class)
@@ -77,7 +77,7 @@ public class DataManagerTest {
         dataManager.update(integration);
 
 		Integration i = dataManager.fetch(Integration.KIND, integration.getId().get());
-		assertEquals("Name should be updated", "new updated name", i.name());
+		assertEquals("Name should be updated", "new updated name", i.getName());
 	}
 
 }

--- a/runtime/src/test/java/com/redhat/ipaas/rest/util/ReflectiveSortComparatorTest.java
+++ b/runtime/src/test/java/com/redhat/ipaas/rest/util/ReflectiveSortComparatorTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.rest.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author roland
+ * @since 13/12/16
+ */
+public class ReflectiveSortComparatorTest {
+
+    @Test
+    public void stringSort() {
+
+        List<TestPerson> toSort = getTestData();
+
+        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "asc")));
+        String[] expectedNames = {
+            "Feynman",
+            "Heisenberg",
+            "Maxwell",
+            "Schrödinger"
+        };
+
+        for (int i = 0; i < expectedNames.length; i++) {
+            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+        }
+
+        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "DESC")));
+        List reversed = Arrays.asList(expectedNames);
+        Collections.reverse(reversed);
+
+        for (int i = 0; i < expectedNames.length; i++) {
+            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+        }
+    }
+
+    @Test
+    public void intSort() {
+        List<TestPerson> toSort = getTestData();
+
+        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("birthYear", null)));
+        String[] expectedNames = {
+            "Maxwell",
+            "Schrödinger",
+            "Heisenberg",
+            "Feynman"
+        };
+
+        for (int i = 0; i < expectedNames.length; i++) {
+            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidType() {
+        getTestData().sort(new ReflectiveSorter<>(TestPerson.class, getOptions("blub", "asc")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidDirection() {
+        getTestData().sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "blub")));
+    }
+
+    @Test
+    public void noParams() {
+        List<TestPerson> toSort = getTestData();
+        Function<List<TestPerson>, List<TestPerson>> operator = new ReflectiveSorter<>(TestPerson.class, getOptions(null, null));
+        operator.apply(toSort);
+
+        String[] expectedNames = {
+            "Schrödinger",
+            "Heisenberg",
+            "Feynman",
+            "Maxwell",
+        };
+
+        for (int i = 0; i < expectedNames.length; i++) {
+            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+        }
+
+    }
+
+    private SortOptions getOptions(String type, String direction) {
+        return new SortOptions() {
+            @Override
+            public String getSortField() {
+                return type;
+            }
+
+            @Override
+            public SortDirection getSortDirection() {
+                return direction != null ? SortDirection.valueOf(direction.toUpperCase()) : SortDirection.ASC;
+            }
+        };
+    }
+
+    private List<TestPerson> getTestData() {
+        return Arrays.asList(
+
+            new TestPerson( "Erwin", "Schrödinger", 1887),
+            new TestPerson( "Werner", "Heisenberg", 1901),
+            new TestPerson("Richard", "Feynman", 1918),
+            new TestPerson( "James Clerk", "Maxwell", 1831)
+
+                            );
+    }
+
+    static class TestPerson {
+
+        private String firstName;
+        private String lastName;
+        private int birthYear;
+
+        TestPerson(String firstName, String lastName, int birthYear) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.birthYear = birthYear;
+        }
+    }
+}

--- a/runtime/src/test/java/com/redhat/ipaas/rest/util/ReflectiveSorterTest.java
+++ b/runtime/src/test/java/com/redhat/ipaas/rest/util/ReflectiveSorterTest.java
@@ -28,14 +28,14 @@ import static org.junit.Assert.assertEquals;
  * @author roland
  * @since 13/12/16
  */
-public class ReflectiveSortComparatorTest {
+public class ReflectiveSorterTest {
 
     @Test
     public void stringSort() {
 
-        List<TestPerson> toSort = getTestData();
+        List<TestPersonInterface> toSort = getTestData();
 
-        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "asc")));
+        toSort.sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("lastName", "asc")));
         String[] expectedNames = {
             "Feynman",
             "Heisenberg",
@@ -44,23 +44,23 @@ public class ReflectiveSortComparatorTest {
         };
 
         for (int i = 0; i < expectedNames.length; i++) {
-            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+            assertEquals(toSort.get(i).getLastName(), expectedNames[i]);
         }
 
-        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "DESC")));
+        toSort.sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("lastName", "DESC")));
         List reversed = Arrays.asList(expectedNames);
         Collections.reverse(reversed);
 
         for (int i = 0; i < expectedNames.length; i++) {
-            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+            assertEquals(toSort.get(i).getLastName(), expectedNames[i]);
         }
     }
 
     @Test
     public void intSort() {
-        List<TestPerson> toSort = getTestData();
+        List<TestPersonInterface> toSort = getTestData();
 
-        toSort.sort(new ReflectiveSorter<>(TestPerson.class, getOptions("birthYear", null)));
+        toSort.sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("birthYear", null)));
         String[] expectedNames = {
             "Maxwell",
             "Schrödinger",
@@ -69,24 +69,24 @@ public class ReflectiveSortComparatorTest {
         };
 
         for (int i = 0; i < expectedNames.length; i++) {
-            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+            assertEquals(toSort.get(i).getLastName(), expectedNames[i]);
         }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidType() {
-        getTestData().sort(new ReflectiveSorter<>(TestPerson.class, getOptions("blub", "asc")));
+        getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("blub", "asc")));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidDirection() {
-        getTestData().sort(new ReflectiveSorter<>(TestPerson.class, getOptions("lastName", "blub")));
+        getTestData().sort(new ReflectiveSorter<>(TestPersonInterface.class, getOptions("lastName", "blub")));
     }
 
     @Test
     public void noParams() {
-        List<TestPerson> toSort = getTestData();
-        Function<List<TestPerson>, List<TestPerson>> operator = new ReflectiveSorter<>(TestPerson.class, getOptions(null, null));
+        List<TestPersonInterface> toSort = getTestData();
+        Function<List<TestPersonInterface>, List<TestPersonInterface>> operator = new ReflectiveSorter<>(TestPersonInterface.class, getOptions(null, null));
         operator.apply(toSort);
 
         String[] expectedNames = {
@@ -97,7 +97,7 @@ public class ReflectiveSortComparatorTest {
         };
 
         for (int i = 0; i < expectedNames.length; i++) {
-            assertEquals(toSort.get(i).lastName, expectedNames[i]);
+            assertEquals(toSort.get(i).getLastName(), expectedNames[i]);
         }
 
     }
@@ -116,7 +116,7 @@ public class ReflectiveSortComparatorTest {
         };
     }
 
-    private List<TestPerson> getTestData() {
+    private List<TestPersonInterface> getTestData() {
         return Arrays.asList(
 
             new TestPerson( "Erwin", "Schrödinger", 1887),
@@ -127,7 +127,16 @@ public class ReflectiveSortComparatorTest {
                             );
     }
 
-    static class TestPerson {
+    interface TestPersonInterface extends TestPersonBase {
+        String getFirstName();
+        int getBirthYear();
+    }
+
+    interface TestPersonBase {
+        String getLastName();
+    }
+
+    static class TestPerson implements TestPersonInterface {
 
         private String firstName;
         private String lastName;
@@ -137,6 +146,18 @@ public class ReflectiveSortComparatorTest {
             this.firstName = firstName;
             this.lastName = lastName;
             this.birthYear = birthYear;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public int getBirthYear() {
+            return birthYear;
         }
     }
 }


### PR DESCRIPTION
You can use the following query parameters:

* "sort" to specify on which field to support. Supported are currently integer and string fields.
* "direction" can be "asc" or "desc" dependening on which direction to sort. Default is "asc"

Still open: Proper Swagger annotation which is probably done via a "Parameters Definition Object" (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameters-definitions-object) so that it doesnt not have to repeated all over all.

Also it would be nice to sort on multiple levels (by providing multiple sort fields) and also on deeper values by allowing a path expression for the field. But thats probably over the top for now ;-)

Interesting also: The DataManager.fetch(...) method can take a list of transformers (like the ReflectiveSorter), so it should be trivial to add paging at that point, too.