### PR TITLE
WIP: Composable REST API

### DIFF
--- a/runtime/src/main/java/com/redhat/ipaas/rest/BaseHandler.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/BaseHandler.java
@@ -15,23 +15,16 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+import javax.inject.Inject;
 
-import javax.ws.rs.Path;
+public class BaseHandler implements WithDataManager {
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
+    @Inject
+    private DataManager dataMgr;
 
     @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
+    public DataManager getDataManager() {
+        return dataMgr;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/ComponentGroups.java
@@ -16,49 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.ComponentGroup;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
 import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.HEAD;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/componentgroups")
 @Api(value = "componentgroups")
-public class ComponentGroups {
+public class ComponentGroups extends BaseHandler implements Lister<ComponentGroup>, Getter<ComponentGroup> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @Context
-    private UriInfo uri;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List component groups")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = ComponentGroup.class)})
-    public Collection<ComponentGroup> list() {
-        return dataMgr.fetchAll(ComponentGroup.KIND, new ReflectiveSorter<>(ComponentGroup.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<ComponentGroup> resourceClass() {
+        return ComponentGroup.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get component group by ID")
-    public ComponentGroup get(
-        @ApiParam(value = "id of the ComponentGroup", required = true) @PathParam("id") String id) {
-        return dataMgr.fetch(ComponentGroup.KIND, id);
+    @Override
+    public String resourceKind() {
+        return ComponentGroup.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Components.java
@@ -16,56 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Component;
-import com.redhat.ipaas.api.v1.model.ComponentGroup;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/components")
 @Api(value = "components")
-public class Components {
+public class Components extends BaseHandler implements Lister<Component>, Getter<Component> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List components")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Component.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<Component> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(Component.KIND, new ReflectiveSorter<>(Component.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<Component> resourceClass() {
+        return Component.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get component by ID")
-    public Component get(
-        @ApiParam(value = "id of the Component", required = true) @PathParam("id") String id) {
-        Component component = dataMgr.fetch(Component.KIND, id);
-        if (component.getComponentGroupId().isPresent()) {
-            ComponentGroup cg = dataMgr.fetch(ComponentGroup.KIND, component.getComponentGroupId().get());
-            component = new Component.Builder().createFrom(component).componentGroup(cg).build();
-        }
-        return component;
+    @Override
+    public String resourceKind() {
+        return Component.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Connections.java
@@ -16,84 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Connection;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/connections")
 @Api(value = "connections")
-public class Connections {
+public class Connections extends BaseHandler implements Lister<Connection>, Getter<Connection>, Creator<Connection>, Deleter<Connection>, Updater<Connection> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List connections")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Connection.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<Connection> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(Connection.KIND, new ReflectiveSorter<>(Connection.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<Connection> resourceClass() {
+        return Connection.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get connection by ID")
-    public Connection get(
-        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
-        return dataMgr.fetch(Connection.KIND, id);
+    @Override
+    public String resourceKind() {
+        return Connection.KIND;
     }
-
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes("application/json")
-    @ApiOperation(value = "Create a new connection")
-    public Connection create(Connection connection) {
-        return dataMgr.create(connection);
-    }
-
-    @PUT
-    @Path(value = "/{id}")
-    @Consumes("application/json")
-    @ApiOperation(value = "Update a connection")
-    public void update(
-        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
-        Connection connection) {
-        dataMgr.update(connection);
-
-    }
-
-    @DELETE
-    @Consumes("application/json")
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Delete a connection")
-    public void delete(
-        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id) {
-        dataMgr.delete(Connection.KIND, id);
-
-    }
-
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Creator.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Creator.java
@@ -15,23 +15,20 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+import com.redhat.ipaas.api.v1.model.WithId;
 
-import javax.ws.rs.Path;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
+public interface Creator<T extends WithId> extends Resource<T>, WithDataManager {
 
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes("application/json")
+    default T create(T obj) {
+        return getDataManager().create(obj);
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Deleter.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Deleter.java
@@ -15,23 +15,20 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+import com.redhat.ipaas.api.v1.model.WithId;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
+public interface Deleter<T extends WithId> extends Resource<T>, WithDataManager {
 
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
+    @DELETE
+    @Consumes("application/json")
+    @Path(value = "/{id}")
+    default void delete(@PathParam("id") String id) {
+        getDataManager().delete(resourceKind(), id);
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Getter.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Getter.java
@@ -15,23 +15,21 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+import com.redhat.ipaas.api.v1.model.WithId;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
+public interface Getter<T extends WithId> extends Resource<T>, WithDataManager {
 
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path(value = "/{id}")
+    default T get(@PathParam("id") String id) {
+        return getDataManager().fetch(resourceKind(), id);
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationPatterns.java
@@ -16,57 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.IntegrationPattern;
-import com.redhat.ipaas.api.v1.model.IntegrationPatternGroup;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/integrationpatterns")
 @Api(value = "integrationpatterns")
-public class IntegrationPatterns {
+public class IntegrationPatterns extends BaseHandler implements Lister<IntegrationPattern>, Getter<IntegrationPattern> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List integration patterns")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationPattern.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<IntegrationPattern> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(IntegrationPattern.KIND,
-            new ReflectiveSorter<>(IntegrationPattern.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<IntegrationPattern> resourceClass() {
+        return IntegrationPattern.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get an integration patten by ID")
-    public IntegrationPattern get(
-        @ApiParam(value = "id of the IntegrationPattern", required = true) @PathParam("id") String id) {
-        IntegrationPattern ip = dataMgr.fetch(IntegrationPattern.KIND, id);
-        if (ip.getIntegrationPatternGroupId().isPresent()) {
-            IntegrationPatternGroup ipg = dataMgr.fetch(IntegrationPatternGroup.KIND, ip.getIntegrationPatternGroupId().get());
-            ip = new IntegrationPattern.Builder().createFrom(ip).integrationPatternGroup(ipg).build();
-        }
-        return ip;
+    @Override
+    public String resourceKind() {
+        return IntegrationPattern.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/IntegrationTemplates.java
@@ -16,85 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.IntegrationTemplate;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/integrationtemplates")
 @Api(value = "integrationtemplates")
-public class IntegrationTemplates {
+public class IntegrationTemplates extends BaseHandler implements Lister<IntegrationTemplate>, Getter<IntegrationTemplate>, Creator<IntegrationTemplate>, Deleter<IntegrationTemplate>, Updater<IntegrationTemplate> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List integration templates")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = IntegrationTemplate.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<IntegrationTemplate> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(IntegrationTemplate.KIND,
-            new ReflectiveSorter<>(IntegrationTemplate.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<IntegrationTemplate> resourceClass() {
+        return IntegrationTemplate.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get an integration template by ID")
-    public IntegrationTemplate get(
-        @ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
-        IntegrationTemplate it = dataMgr.fetch(IntegrationTemplate.KIND, id);
-
-        return it;
-    }
-
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes("application/json")
-    @ApiOperation(value = "Create an integration template")
-    public IntegrationTemplate create(IntegrationTemplate integrationTemplate) {
-        return dataMgr.create(integrationTemplate);
-    }
-
-    @PUT
-    @Path(value = "/{id}")
-    @Consumes("application/json")
-    @ApiOperation(value = "Update a connection")
-    public void update(
-        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
-        IntegrationTemplate integrationTemplate) {
-        dataMgr.update(integrationTemplate);
-
-    }
-
-    @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Delete an integration template")
-    public void delete(
-        @ApiParam(value = "id of the IntegrationTemplate", required = true) @PathParam("id") String id) {
-        dataMgr.delete(IntegrationTemplate.KIND, id);
+    @Override
+    public String resourceKind() {
+        return IntegrationTemplate.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Integrations.java
@@ -16,87 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Integration;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/integrations")
 @Api(value = "integrations")
-public class Integrations {
+public class Integrations extends BaseHandler implements Lister<Integration>, Getter<Integration>, Creator<Integration>, Deleter<Integration>, Updater<Integration> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @Context
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List integrations")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Integration.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<Integration> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(Integration.KIND,
-            new ReflectiveSorter<>(Integration.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<Integration> resourceClass() {
+        return Integration.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get an integration by ID")
-    public Integration get(
-        @ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
-        Integration i = dataMgr.fetch(Integration.KIND, id);
-
-        return i;
+    @Override
+    public String resourceKind() {
+        return Integration.KIND;
     }
-
-    @POST
-    @Produces(MediaType.APPLICATION_JSON)
-    @Consumes("application/json")
-    @ApiOperation(value = "Create an integration")
-    public Integration create(Integration integration) {
-        return dataMgr.create(integration);
-    }
-
-    @PUT
-    @Path(value = "/{id}")
-    @Consumes("application/json")
-    @ApiOperation(value = "Update a connection")
-    public void update(
-        @ApiParam(value = "id of the connection", required = true) @PathParam("id") String id,
-        Integration integration) {
-        dataMgr.update(integration);
-
-    }
-
-    @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Delete a connection")
-    public void delete(
-        @ApiParam(value = "id of the Integration", required = true) @PathParam("id") String id) {
-        dataMgr.delete(Integration.KIND, id);
-    }
-
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Lister.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Lister.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.rest;
+
+import com.redhat.ipaas.api.v1.model.WithId;
+import com.redhat.ipaas.rest.util.ReflectiveSorter;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+import java.util.Collection;
+
+public interface Lister<T extends WithId> extends Resource<T>, WithDataManager {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+            name = "sort", value = "Sort the result list according to the given field value",
+            paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
+            "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+
+    })
+    default Collection<T> list(@Context UriInfo uriInfo) {
+        return getDataManager().fetchAll(resourceKind(), new ReflectiveSorter<>(resourceClass(), new SortOptionsFromQueryParams(uriInfo)));
+    }
+
+}

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Organizations.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Organizations.java
@@ -16,24 +16,20 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Organization;
-import io.swagger.annotations.ApiOperation;
 
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import java.util.HashSet;
-import java.util.Set;
 
 @Path("/organizations")
-public class Organizations {
+public class Organizations  extends BaseHandler implements Lister<Organization>, Getter<Organization> {
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get an organization by ID")
-    public Set<Organization> doGet() {
-
-        Set<Organization> orgs = new HashSet<>();
-        return orgs;
+    @Override
+    public Class<Organization> resourceClass() {
+        return Organization.class;
     }
+
+    @Override
+    public String resourceKind() {
+        return Organization.KIND;
+    }
+
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Permissions.java
@@ -16,53 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Permission;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/permissions")
 @Api(value = "permissions")
-public class Permissions {
+public class Permissions extends BaseHandler implements Lister<Permission>, Getter<Permission> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List permissions")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Permission.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<Permission> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(Permission.KIND,
-            new ReflectiveSorter<>(Permission.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<Permission> resourceClass() {
+        return Permission.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get a permission by ID")
-    public Permission get(
-        @ApiParam(value = "id of the Permission", required = true) @PathParam("id") String id) {
-        Permission permission = dataMgr.fetch(Permission.KIND, id);
-
-        return permission;
+    @Override
+    public String resourceKind() {
+        return Permission.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Resource.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Resource.java
@@ -15,23 +15,10 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+public interface Resource<T> {
 
-import javax.ws.rs.Path;
+    Class<T> resourceClass();
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
-
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
-    }
+    String resourceKind();
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Roles.java
@@ -16,53 +16,22 @@
 package com.redhat.ipaas.rest;
 
 import com.redhat.ipaas.api.v1.model.Role;
-import com.redhat.ipaas.rest.util.ReflectiveSorter;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 @Path("/roles")
 @Api(value = "roles")
-public class Roles {
+public class Roles extends BaseHandler implements Lister<Role>, Getter<Role> {
 
-    @Inject
-    private DataManager dataMgr;
-
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "List roles")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Success", response = Role.class)})
-    @ApiImplicitParams({
-        @ApiImplicitParam(
-            name = "sort", value = "Sort the result list according to the given field value",
-            paramType = "query", dataType = "string"),
-        @ApiImplicitParam(
-            name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-                                        "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
-
-    })
-    public Collection<Role> list(@Context UriInfo uri) {
-        return dataMgr.fetchAll(Role.KIND,
-            new ReflectiveSorter<>(Role.class, new SortOptionsFromQueryParams(uri)));
+    @Override
+    public Class<Role> resourceClass() {
+        return Role.class;
     }
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @Path(value = "/{id}")
-    @ApiOperation(value = "Get a role by ID")
-    public Role get(
-        @ApiParam(value = "id of the Role", required = true) @PathParam("id") String id) {
-        Role role = dataMgr.fetch(Role.KIND, id);
-
-        return role;
+    @Override
+    public String resourceKind() {
+        return Role.KIND;
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/Updater.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/Updater.java
@@ -15,23 +15,20 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+import com.redhat.ipaas.api.v1.model.WithId;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
+public interface Updater<T extends WithId> extends Resource<T>, WithDataManager {
 
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
+    @PUT
+    @Path(value = "/{id}")
+    @Consumes("application/json")
+    default void update(@PathParam("id") String id, T obj) {
+        getDataManager().update(obj);
     }
 
 }

--- a/runtime/src/main/java/com/redhat/ipaas/rest/WithDataManager.java
+++ b/runtime/src/main/java/com/redhat/ipaas/rest/WithDataManager.java
@@ -15,23 +15,8 @@
  */
 package com.redhat.ipaas.rest;
 
-import com.redhat.ipaas.api.v1.model.User;
-import io.swagger.annotations.Api;
+public interface WithDataManager {
 
-import javax.ws.rs.Path;
-
-@Path("/users")
-@Api(value = "users")
-public class Users extends BaseHandler implements Lister<User>, Getter<User> {
-
-    @Override
-    public Class<User> resourceClass() {
-        return User.class;
-    }
-
-    @Override
-    public String resourceKind() {
-        return User.KIND;
-    }
+    DataManager getDataManager();
 
 }


### PR DESCRIPTION
Would love feedback on this approach to ensure a consistent API with little repeated code. The approach uses default methods on interfaces to act like traits to compose functionality in the REST API layer.

One outstanding problems is Swagger descriptions: generics don't play nicely with swagger and description strings in annotations need to be constants. I'm thinking of using annotation processing to generate implementations of these interfaces, supplying annotations on the managed model classes. These generated classes would of course not be editable, but we can also generate a subclassed implementation where we can extend or override as needed.

I've tested this with the iPaaS UI & it all works fine :)