### PR TITLE
Add pagination options to API via query_params

### DIFF
--- a/api/src/main/java/com/redhat/ipaas/api/v1/model/ListResult.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/model/ListResult.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.model;
+
+import org.immutables.value.Value;
+
+import java.util.Collection;
+
+/**
+ * Holds the result of a list, including the total count of elements. This is used by the client for working out paging
+ * when viewing a large list.
+ *
+ * @param <T> The type of the elements in the returned list.
+ */
+@Value.Immutable
+public interface ListResult<T extends WithId> {
+
+    /**
+     *
+     * @return The total count of entities available.
+     */
+    int getTotalCount();
+
+    /**
+     *
+     * @return The filtered list of items. Depending on operations, this will contain at most getTotalCount elements.
+     */
+    Collection<T> getItems();
+
+    class Builder<T extends WithId> extends ImmutableListResult.Builder<T> {
+    }
+
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/DataManager.java
@@ -28,6 +28,7 @@ import com.redhat.ipaas.api.v1.model.IntegrationPatternGroup;
 import com.redhat.ipaas.api.v1.model.IntegrationRuntime;
 import com.redhat.ipaas.api.v1.model.IntegrationTemplate;
 import com.redhat.ipaas.api.v1.model.IntegrationTemplateConnectionStep;
+import com.redhat.ipaas.api.v1.model.ListResult;
 import com.redhat.ipaas.api.v1.model.Organization;
 import com.redhat.ipaas.api.v1.model.Permission;
 import com.redhat.ipaas.api.v1.model.Role;
@@ -179,13 +180,14 @@ public class DataManager {
     }
 
     @SuppressWarnings("unchecked")
-    public <T> List<T> fetchAll(String model, Function<List<T>, List<T>>... operators) {
+    public <T extends WithId> ListResult<T> fetchAll(String model, Function<List<T>, List<T>>... operators) {
         Map<String, WithId> entityMap = cache.computeIfAbsent(model, k -> new HashMap<>());
         List<T> result = new ArrayList<>((Collection<? extends T>) entityMap.values());
+        int totalCount = result.size();
         for (Function<List<T>, List<T>> operator : operators) {
             result = operator.apply(result);
         }
-        return result;
+        return new ListResult.Builder<T>().totalCount(totalCount).items(result).build();
     }
 
     public <T> T fetch(String model, String id) {

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/JacksonContextResolver.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/JacksonContextResolver.java
@@ -33,7 +33,7 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
     public JacksonContextResolver() throws Exception {
         this.objectMapper = new ObjectMapper().
             registerModule(new Jdk8Module()).
-            setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+            setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     public ObjectMapper getContext(Class<?> objectType) {

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/Lister.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/Lister.java
@@ -15,10 +15,10 @@
  */
 package com.redhat.ipaas.api.v1.rest;
 
+import com.redhat.ipaas.api.v1.model.ListResult;
 import com.redhat.ipaas.api.v1.model.WithId;
-import com.redhat.ipaas.api.v1.rest.SortOptionsFromQueryParams;
+import com.redhat.ipaas.api.v1.rest.util.PaginationFilter;
 import com.redhat.ipaas.api.v1.rest.util.ReflectiveSorter;
-
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 
@@ -27,7 +27,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
-import java.util.Collection;
 
 public interface Lister<T extends WithId> extends Resource<T>, WithDataManager {
 
@@ -39,11 +38,19 @@ public interface Lister<T extends WithId> extends Resource<T>, WithDataManager {
             paramType = "query", dataType = "string"),
         @ApiImplicitParam(
             name = "direction", value = "Sorting direction when a 'sort' field is provided. Can be 'asc' " +
-            "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string")
+            "(ascending) or 'desc' (descending)", paramType = "query", dataType = "string"),
+        @ApiImplicitParam(
+            name = "page", value = "Page number to return", paramType = "query", dataType = "integer", defaultValue = "1"),
+        @ApiImplicitParam(
+            name = "per_page", value = "Number of records per page", paramType = "query", dataType = "integer", defaultValue = "20")
 
     })
-    default Collection<T> list(@Context UriInfo uriInfo) {
-        return getDataManager().fetchAll(resourceKind(), new ReflectiveSorter<>(resourceClass(), new SortOptionsFromQueryParams(uriInfo)));
+    default ListResult<T> list(@Context UriInfo uriInfo) {
+        return getDataManager().fetchAll(
+            resourceKind(),
+            new ReflectiveSorter<>(resourceClass(), new SortOptionsFromQueryParams(uriInfo)),
+            new PaginationFilter<>(new PaginationOptionsFromQueryParams(uriInfo))
+        );
     }
 
 }

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/PaginationOptionsFromQueryParams.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/PaginationOptionsFromQueryParams.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.rest;
+
+import com.redhat.ipaas.api.v1.rest.util.PaginationOptions;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Extracts the pagination options from the request.
+ */
+class PaginationOptionsFromQueryParams implements PaginationOptions {
+
+    private final int page;
+    private final int perPage;
+
+    /**
+     *  Extracts the pagination options from the request.
+     * @param uri The request context.
+     */
+    PaginationOptionsFromQueryParams(UriInfo uri) {
+        MultivaluedMap<String, String> queryParams = uri.getQueryParameters();
+        String pageQuery = queryParams.getFirst("page");
+        if (pageQuery == null || pageQuery.isEmpty()) {
+            page = 1;
+        } else {
+            page = Integer.parseInt(pageQuery);
+        }
+
+        String perPageQuery = queryParams.getFirst("per_page");
+        if (perPageQuery == null || perPageQuery.isEmpty()) {
+            perPage = 20;
+        } else {
+            perPage = Integer.parseInt(perPageQuery);
+        }
+    }
+
+    /**
+     *
+     * @return The requested page number.
+     */
+    public int getPage() {
+        return page;
+    }
+
+    /**
+     *
+     * @return The requested number per page.
+     */
+    public int getPerPage() {
+        return perPage;
+    }
+
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/util/PaginationFilter.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/util/PaginationFilter.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.rest.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Filters the list with the provided pagination options.
+ *
+ * @param <T> The type of the elements in the filtered list.
+ */
+public class PaginationFilter<T> implements Function<List<T>, List<T>> {
+
+    private final int startIndex;
+    private final int endIndex;
+
+    /**
+     * Creates the filter with the specified pagination options.
+     *
+     * @param options The pagination options. Note that page and per_page must both be greater than 0.
+     * @throws IllegalArgumentException If page or perPage are less than 1.
+     */
+    public PaginationFilter(PaginationOptions options) {
+        if (options.getPage() < 1) {
+            throw new IllegalArgumentException("Page number must be greater than 0");
+        }
+        if (options.getPerPage() < 1) {
+            throw new IllegalArgumentException("Per page must be greater than 0");
+        }
+        this.startIndex = (options.getPage() - 1) * options.getPerPage();
+        this.endIndex = options.getPage() * options.getPerPage();
+    }
+
+    /**
+     * Applies the filter to the provided list.
+     *
+     * @param list The list to filter.
+     * @return The relevant page of the provided list. Returns an empty list if the requested page would be outside of the provided list range.
+     */
+    @Override
+    public List<T> apply(List<T> list) {
+        if (startIndex >= list.size()) {
+            return Collections.emptyList();
+        }
+        return list.subList(startIndex, Math.min(list.size(), endIndex));
+    }
+
+}

--- a/api/src/main/java/com/redhat/ipaas/api/v1/rest/util/PaginationOptions.java
+++ b/api/src/main/java/com/redhat/ipaas/api/v1/rest/util/PaginationOptions.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.rest.util;
+
+/**
+ * Options used to specify the requested page of the list.
+ */
+public interface PaginationOptions {
+
+    /**
+     *
+     * @return The requested page number.
+     */
+    int getPage();
+
+    /**
+     *
+     * @return The requested number per page.
+     */
+    int getPerPage();
+
+}

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/DataManagerTest.java
@@ -17,12 +17,15 @@ package com.redhat.ipaas.api.v1.rest;
 
 import com.redhat.ipaas.api.v1.model.Component;
 import com.redhat.ipaas.api.v1.model.Integration;
+import com.redhat.ipaas.api.v1.model.ListResult;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import javax.persistence.EntityExistsException;
-import java.util.Collection;
+
+import java.util.List;
+import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,11 +45,26 @@ public class DataManagerTest {
 
     @Test
     public void getComponents() {
-        Collection<Component> components = dataManager.fetchAll(Component.KIND);
-        for (Component component : components) {
+        ListResult<Component> components = dataManager.fetchAll(Component.KIND);
+        for (Component component : components.getItems()) {
             System.out.print(component.getId().get() + ",");
         }
-        assertTrue(components.size() > 10);
+        assertTrue(components.getTotalCount() > 10);
+        assertTrue(components.getItems().size() > 10);
+        assertEquals(components.getTotalCount(), components.getItems().size());
+    }
+
+    @Test
+    public void getComponentsWithFilterFunction() {
+        ListResult<Component> components = dataManager.fetchAll(
+            Component.KIND,
+            (Function<List<Component>, List<Component>>) componentList -> componentList.subList(0, 1)
+        );
+        for (Component component : components.getItems()) {
+            System.out.print(component.getId().get() + ",");
+        }
+        assertTrue(components.getTotalCount() > 10);
+        assertEquals(1, components.getItems().size());
     }
 
     @Test

--- a/api/src/test/java/com/redhat/ipaas/api/v1/rest/util/PaginationFilterTest.java
+++ b/api/src/test/java/com/redhat/ipaas/api/v1/rest/util/PaginationFilterTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.ipaas.api.v1.rest.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class PaginationFilterTest {
+
+    private static List<Integer> ints = Arrays.asList(1, 2, 3, 4, 5);
+    private final Parameter parameter;
+
+    public PaginationFilterTest(Parameter parameter) {
+        this.parameter = parameter;
+    }
+
+    @Parameterized.Parameters
+    public static List<Parameter> getParameters() {
+        return Arrays.asList(
+            new Parameter(1, 1, ints, Arrays.asList(1), null),
+            new Parameter(2, 1, ints, Arrays.asList(2), null),
+            new Parameter(2, 3, ints, Arrays.asList(4, 5), null),
+            new Parameter(1, 5, ints, Arrays.asList(1, 2, 3, 4, 5), null),
+            new Parameter(2, 5, ints, Collections.emptyList(), null),
+            new Parameter(-1, 1, ints, null, IllegalArgumentException.class),
+            new Parameter(1, -1, ints, null, IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    public void apply() throws Exception {
+        try {
+            List<Integer> filtered = new PaginationFilter<Integer>(new PaginationOptions() {
+                @Override
+                public int getPage() {
+                    return PaginationFilterTest.this.parameter.page;
+                }
+
+                @Override
+                public int getPerPage() {
+                    return PaginationFilterTest.this.parameter.perPage;
+                }
+            }).apply(parameter.inputList);
+
+            assertEquals(parameter.outputList, filtered);
+        } catch (Exception e) {
+            if (parameter.expectedException == null) {
+                throw e;
+            }
+            assertEquals(parameter.expectedException, e.getClass());
+            return;
+        }
+        if (parameter.expectedException != null) {
+            fail("Expected exception " + parameter.expectedException);
+        }
+    }
+
+    private static class Parameter {
+        int page;
+        int perPage;
+        List<Integer> inputList;
+        List<Integer> outputList;
+        Class<? extends Exception> expectedException;
+
+        Parameter(int page, int perPage, List<Integer> inputList, List<Integer> outputList, Class<? extends Exception> expectedException) {
+            this.page = page;
+            this.perPage = perPage;
+            this.inputList = inputList;
+            this.outputList = outputList;
+            this.expectedException = expectedException;
+        }
+    }
+
+}


### PR DESCRIPTION
This also serializes empty collections as well to be more explicit for clients.

@kahboom @gashcrumb This is place for when you look at doing virtual scrolling stuff, whenever that is.